### PR TITLE
fix: add HTTP request timeouts, parameterize SDK URL, and prevent node crash

### DIFF
--- a/earthrovers_base/earthrovers_base/base.py
+++ b/earthrovers_base/earthrovers_base/base.py
@@ -114,7 +114,7 @@ class BaseNode(Node):
         # Finally, send the POST request to the SDK API.
         start = time.perf_counter()
         try:
-            response = requests.post(f"{sdk_url}/control", json=payload)
+            response = requests.post(f"{sdk_url}/control", json=payload, timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"POST request to SDK API failed: {e}")
             return
@@ -146,7 +146,7 @@ class BaseNode(Node):
         start = time.perf_counter()
         try:
             self.get_logger().debug(f"Making GET request to {earthrover_sdk_url}/data")
-            response = requests.get(f"{earthrover_sdk_url}/data")
+            response = requests.get(f"{earthrover_sdk_url}/data", timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to get data: {e}")
             return

--- a/earthrovers_navigation/earthrovers_navigation/mission_controller.py
+++ b/earthrovers_navigation/earthrovers_navigation/mission_controller.py
@@ -42,7 +42,7 @@ class MissionController(Node):
         try:
             self.get_logger().info("Making request to start mission.")
             self.get_logger().debug(f"Making POST request to {earthrover_sdk_url}/start_mission")
-            post_response = requests.post(f"{earthrover_sdk_url}/start-mission")
+            post_response = requests.post(f"{earthrover_sdk_url}/start-mission", timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to start mission: {e}")
             response.mission_started = False
@@ -87,7 +87,7 @@ class MissionController(Node):
         try:
             self.get_logger().info("Making request to end mission.")
             self.get_logger().debug(f"Making POST request to {earthrover_sdk_url}/end_mission")
-            post_response = requests.post(f"{earthrover_sdk_url}/end-mission")
+            post_response = requests.post(f"{earthrover_sdk_url}/end-mission", timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to end mission: {e}")
             response.mission_ended = False
@@ -138,7 +138,7 @@ class MissionController(Node):
         try:
             self.get_logger().info("Making request to checkpoint reached.")
             self.get_logger().debug(f"Making POST request to {earthrover_sdk_url}/checkpoint-reached")
-            post_response = requests.post(f"{earthrover_sdk_url}/checkpoint-reached", json={})
+            post_response = requests.post(f"{earthrover_sdk_url}/checkpoint-reached", json={}, timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to check if checkpoint reached with error: {e}")
             response.checkpoint_reached = False
@@ -199,7 +199,7 @@ class MissionController(Node):
         try:
             self.get_logger().info("Making request to get checkpoints.")
             self.get_logger().debug(f"Making GET request to {earthrover_sdk_url}/checkpoints-list")
-            get_response = requests.get(f"{earthrover_sdk_url}/checkpoints-list")
+            get_response = requests.get(f"{earthrover_sdk_url}/checkpoints-list", timeout=5.0)
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Request to get checkpoints failed with error: {e}")
             response.checkpoints = []

--- a/earthrovers_navigation/earthrovers_navigation/waypoint_receiver.py
+++ b/earthrovers_navigation/earthrovers_navigation/waypoint_receiver.py
@@ -26,14 +26,15 @@ class WaypointReceiverNode(Node):
         check_checkpoint_reached_period = 5.0
         self.create_timer(get_checkpoint_list_period, self.get_checkpoints_list)
         self.create_timer(check_checkpoint_reached_period, self.check_checkpoint_reached)
-        self.earthrover_sdk_url = "http://127.0.0.1:8000"
+        self.declare_parameter("earthrover_sdk_url", "http://127.0.0.1:8000")
+        self.earthrover_sdk_url = self.get_parameter("earthrover_sdk_url").get_parameter_value().string_value
 
     def get_checkpoints_list(self):
         checkpoints_list = GeoPath()
         latest_scanned_checkpoint = -1
         start_time = time.time()
         try:
-            checkpoints_list_response = requests.get(f"{self.earthrover_sdk_url}/checkpoints-list")
+            checkpoints_list_response = requests.get(f"{self.earthrover_sdk_url}/checkpoints-list", timeout=5.0)
             # Parse the checkpoints from the response and create a list of
             # of Waypoint messages.
             if checkpoints_list_response.status_code == 200:
@@ -54,17 +55,20 @@ class WaypointReceiverNode(Node):
 
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to get checkpoints list: {e}")
-            raise Exception("Failed to get checkpoints list.")
+            return
         print("Published checkpoints list of length: ", len(checkpoints_list.poses))
         print([f"{pose.pose.position.latitude}, {pose.pose.position.longitude}" for pose in checkpoints_list.poses])
         self.waypoints_pub.publish(checkpoints_list)
 
     def check_checkpoint_reached(self):
         start_time = time.time()
-        checkpoint_reached_response = requests.post(f"{self.earthrover_sdk_url}/checkpoint-reached", json={})
-        checkpoint_reached_response_json = checkpoint_reached_response.json()
-        print(f"Checkpoint reached response: {checkpoint_reached_response_json}")
-        print(f"Time taken to get checkpoint reached response: {time.time() - start_time}")
+        try:
+            checkpoint_reached_response = requests.post(f"{self.earthrover_sdk_url}/checkpoint-reached", json={}, timeout=5.0)
+            checkpoint_reached_response_json = checkpoint_reached_response.json()
+            print(f"Checkpoint reached response: {checkpoint_reached_response_json}")
+            print(f"Time taken to get checkpoint reached response: {time.time() - start_time}")
+        except requests.exceptions.RequestException as e:
+            self.get_logger().error(f"Failed to check checkpoint reached: {e}")
 
 
 def main(args=None):

--- a/earthrovers_vision/earthrovers_vision/cameras.py
+++ b/earthrovers_vision/earthrovers_vision/cameras.py
@@ -106,7 +106,7 @@ class CameraNode(Node):
         earth_rover_sdk_url = self.get_parameter("earthrover_sdk_url").get_parameter_value().string_value
         start = time.perf_counter()
         try:
-            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=front")
+            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=front", timeout=5.0)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to get front camera image: {e}")
@@ -148,7 +148,7 @@ class CameraNode(Node):
         earth_rover_sdk_url = self.get_parameter("earthrover_sdk_url").get_parameter_value().string_value
         start = time.perf_counter()
         try:
-            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=rear")
+            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=rear", timeout=5.0)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to get rear camera image: {e}")
@@ -189,7 +189,7 @@ class CameraNode(Node):
         earth_rover_sdk_url = self.get_parameter("earthrover_sdk_url").get_parameter_value().string_value
         start = time.perf_counter()
         try:
-            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=map")
+            response = requests.get(f"{earth_rover_sdk_url}/screenshot?view_types=map", timeout=5.0)
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             self.get_logger().error(f"Failed to get map image: {e}")


### PR DESCRIPTION
## Summary
- Add 5-second timeout to all `requests.get()` and `requests.post()` calls across all nodes (11 total)
- Parameterize the hardcoded SDK URL in `waypoint_receiver.py` using `declare_parameter()`, consistent with other nodes
- Fix crash in `waypoint_receiver.py` where `raise Exception()` kills the entire ROS node on request failure
- Add error handling to `check_checkpoint_reached()` which had no try/except

## Why
### Missing timeouts (reliability + safety)
All HTTP requests to the Earth Rover SDK had no timeout configured. If the SDK becomes unresponsive, the calling thread blocks **indefinitely**. This is critical for `_cmd_vel_callback` in `base.py` — a hanging request means the rover cannot receive stop commands, creating a safety hazard.

### Hardcoded SDK URL
`waypoint_receiver.py` hardcoded `self.earthrover_sdk_url = "http://127.0.0.1:8000"` instead of using `self.declare_parameter()` like `base.py`, `mission_controller.py`, and `cameras.py`. This made it impossible to configure the SDK URL at launch time for this node.

### Node crash on request failure
`waypoint_receiver.py` re-raised a generic `Exception` after catching `RequestException`, crashing the entire navigation node on any SDK connection failure. Replaced with `return` to match the graceful error handling pattern used elsewhere. Also added try/except to `check_checkpoint_reached()` which had no error handling at all.

## Files changed
- `earthrovers_base/earthrovers_base/base.py` — timeout on 2 requests
- `earthrovers_navigation/earthrovers_navigation/waypoint_receiver.py` — parameterize URL, timeout on 2 requests, fix crash, add error handling
- `earthrovers_navigation/earthrovers_navigation/mission_controller.py` — timeout on 4 requests
- `earthrovers_vision/earthrovers_vision/cameras.py` — timeout on 3 requests

## Test plan
- [ ] Verify all nodes start and operate normally with SDK running
- [ ] Verify nodes handle SDK unavailability gracefully (no crashes, no hangs)
- [ ] Verify `waypoint_receiver` accepts `earthrover_sdk_url` as a launch parameter
- [ ] Verify timeout fires correctly when SDK is unresponsive